### PR TITLE
Dockerize frontend with nginx and add to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,16 @@ services:
       PRODUCT_SERVICE: product:50052
       JWT_SECRET_KEY: change-me
       ENVIRONMENT: development
+  frontend:
+    container_name: frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - "3000:80"
+    depends_on:
+      - apigateway
 volumes:
   orders-data:
   inventory-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://apigateway:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
- Add frontend Dockerfile (multi-stage: node build + nginx serve)
- Add nginx.conf with /api/ proxy to apigateway and SPA fallback
- Add frontend service to docker-compose.yml on host port 3000