### PR TITLE
Wire auth service into API gateway

### DIFF
--- a/cmd/payflow/apigateway/main.go
+++ b/cmd/payflow/apigateway/main.go
@@ -19,7 +19,7 @@ func main() {
 	logger := logger.InitLogger("apigateway", "development")
 	cfg := config.NewConfig()
 
-	httpHandler, err := router.NewRouter(ctx, logger, cfg.ProductService, cfg.OrderService)
+	httpHandler, err := router.NewRouter(ctx, logger, cfg.ProductService, cfg.OrderService, cfg.AuthService)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to initialize API Gateway router")
 	}

--- a/internal/apigateway/config/config.go
+++ b/internal/apigateway/config/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	Port           string
 	OrderService   string
 	ProductService string
+	AuthService    string
 	JWTSecretKey   string
 }
 
@@ -16,6 +17,7 @@ func NewConfig() Config {
 		Port:           env.GetEnvOrPanic("APIGATEWAY_PORT"),
 		OrderService:   env.GetEnvOrPanic("ORDER_SERVICE"),
 		ProductService: env.GetEnvOrPanic("PRODUCT_SERVICE"),
+		AuthService:    env.GetEnvOrPanic("AUTH_SERVICE"),
 		JWTSecretKey:   env.GetEnvOrPanic("JWT_SECRET_KEY"),
 	}
 }

--- a/internal/apigateway/middleware/auth.go
+++ b/internal/apigateway/middleware/auth.go
@@ -13,9 +13,20 @@ import (
 	"github.com/skhanal5/payflow/internal/shared/auth"
 )
 
+var publicPaths = map[string]bool{
+	"/health":            true,
+	"/api/auth/login":    true,
+	"/api/auth/register": true,
+}
+
 func AuthMiddleware(logger zerolog.Logger, jwtSecret string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if publicPaths[r.URL.Path] {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
 				logger.Warn().Str("path", r.URL.Path).Msg("Missing Authorization header")

--- a/internal/apigateway/router/router.go
+++ b/internal/apigateway/router/router.go
@@ -10,13 +10,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	authgw "github.com/skhanal5/payflow/gen/go/auth"
 	ordergw "github.com/skhanal5/payflow/gen/go/order"
 	productgw "github.com/skhanal5/payflow/gen/go/product"
 
 	"github.com/skhanal5/payflow/internal/apigateway/handler"
 )
 
-func NewRouter(ctx context.Context, logger zerolog.Logger, productAddr, orderAddr string) (http.Handler, error) {
+func NewRouter(ctx context.Context, logger zerolog.Logger, productAddr, orderAddr, authAddr string) (http.Handler, error) {
 	gwmux := runtime.NewServeMux()
 
 	dialOpts := []grpc.DialOption{
@@ -46,6 +47,18 @@ func NewRouter(ctx context.Context, logger zerolog.Logger, productAddr, orderAdd
 		return nil, fmt.Errorf("failed to register order service gateway: %w", err)
 	}
 	logger.Info().Msg("Registered order service gateway handler")
+
+	err = authgw.RegisterAuthServiceHandlerFromEndpoint(
+		ctx,
+		gwmux,
+		authAddr,
+		dialOpts,
+	)
+	if err != nil {
+		logger.Error().Err(err).Msgf("Failed to register auth service gateway handler from endpoint %s", authAddr)
+		return nil, fmt.Errorf("failed to register auth service gateway: %w", err)
+	}
+	logger.Info().Msg("Registered auth service gateway handler")
 
 	mainMux := http.NewServeMux()
 

--- a/internal/auth/config/config.go
+++ b/internal/auth/config/config.go
@@ -3,12 +3,12 @@ package config
 import "github.com/skhanal5/payflow/internal/shared/env"
 
 type Config struct {
-	DBHost     string
-	DBUser     string
-	DBPassword string
-	DBPort     string
-	GRPCPort   string
-	JWTSecret  string
+	DBHost      string
+	DBUser      string
+	DBPassword  string
+	DBPort      string
+	GRPCPort    string
+	JWTSecret   string
 	Environment string
 }
 


### PR DESCRIPTION
- Register auth gRPC service routes in gateway router
- Add AuthService address to gateway config
- Skip auth middleware on /health, /api/auth/login, /api/auth/register