### PR TITLE
Fix some bugs and other misc changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,29 @@
 # Payflow — Agent Guide
 
-Go monorepo: 2 gRPC services (order, product) + HTTP API gateway, Kafka async messaging, PostgreSQL, React frontend.
+Go monorepo: 3 gRPC services (order, product, auth) + HTTP API gateway, Kafka async messaging, PostgreSQL, React frontend.
 
 ## Entrypoints
 
 | Service | File | gRPC Port |
 |---|---|---|
 | API gateway (HTTP) | `cmd/payflow/apigateway/main.go` | N/A (HTTP on `APIGATEWAY_PORT`) |
+| Auth | `cmd/payflow/auth/main.go` | `AUTH_GRPC_PORT` |
 | Order | `cmd/payflow/order/main.go` | `ORDER_GRPC_PORT` |
 | Product | `cmd/payflow/product/main.go` | `PRODUCT_GRPC_PORT` |
 
 Order emits `order.requested` → Kafka, consumes `inventory.checked` from Kafka.
 Product consumes `order.requested` → Kafka, emits `inventory.checked` to Kafka.
+Auth handles login/register via gRPC (no Kafka).
 
 ## Infrastructure (Docker Compose)
 
 - **broker**: Kafka 3.9.1 single-node (KRaft, port 9092)
+- **auth-db**: Postgres 15 on port 5434, init from `sql/init_auth.sql`
 - **order-db**: Postgres 15 on port 5432, init from `sql/init_order.sql`
 - **inventory-db**: Postgres 15 on port 5433, init from `sql/init_inventory.sql`
-- **apigateway**: HTTP on host port 8080, proxies REST→gRPC to order + product
+- **apigateway**: HTTP on host port 8080, proxies REST→gRPC to auth + order + product
 - **frontend**: nginx serving SPA on host port 3000
-- **pgAdmin** on port 8888, **Dozzle** (logs) on port 8080 (note: port conflict with apigateway)
+- **pgAdmin** on port 8888, **Dozzle** (logs) on port 8081
 
 Schema applied via Postgres `docker-entrypoint-initdb.d` scripts — no Flyway.
 
@@ -67,4 +70,6 @@ Enables pre-push hook: `go fmt` → `go vet` → `golangci-lint`.
 
 **Product**: `ORDER_REQUESTED_TOPIC`, `INVENTORY_CHECKED_TOPIC`, `INVENTORY_DB_HOST`, `INVENTORY_DB_USERNAME`, `INVENTORY_DB_PASSWORD`, `INVENTORY_DB_PORT`, `PRODUCT_GRPC_PORT`
 
-**API gateway**: `APIGATEWAY_PORT`, `ORDER_SERVICE`, `PRODUCT_SERVICE`, `JWT_SECRET_KEY`
+**Auth**: `AUTH_DB_HOST`, `AUTH_DB_USER`, `AUTH_DB_PASSWORD`, `AUTH_DB_PORT`, `AUTH_GRPC_PORT`, `JWT_SECRET_KEY`
+
+**API gateway**: `APIGATEWAY_PORT`, `ORDER_SERVICE`, `PRODUCT_SERVICE`, `AUTH_SERVICE`, `JWT_SECRET_KEY`

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,14 @@ restart:
 restart-db:
 	docker restart order-db
 	docker restart inventory-db
+	docker restart auth-db
 
 inventory-service:
 	mkdir -p bin
 	export $$(cat .env | xargs) && go build -o bin/inventory-service ./cmd/payflow/product/main.go
 
 ps:
-	docker-compose ps
+	docker compose ps
 
 frontend-install:
 	cd frontend && npm install
@@ -49,4 +50,4 @@ help:
 	@echo "  ps       - List the status of the containers"
 	@echo "  rund     - Remove and run the containers"
 	@echo "  restart  - Restart all containers"
-	@echo "  prune    - Remove containers, networks, and volumes"
+	@echo "  clean    - Remove containers, networks, and volumes"

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 ## Payflow
 
-Learning how to build a transaction processing system — Go monorepo with 2 gRPC services, an HTTP API gateway, Kafka async messaging, and PostgreSQL.
+Learning how to build a transaction processing system — Go monorepo with 3 gRPC services, an HTTP API gateway, Kafka async messaging, and PostgreSQL.
 
 ### Services
 
 | Service | Entrypoint | Port |
 |---|---|---|
 | API gateway (HTTP) | `cmd/payflow/apigateway/main.go` | Configurable via `APIGATEWAY_PORT` |
+| Auth (gRPC + JWT) | `cmd/payflow/auth/main.go` | Configurable via `AUTH_GRPC_PORT` |
 | Product (gRPC + Kafka consumer) | `cmd/payflow/product/main.go` | Configurable via `PRODUCT_GRPC_PORT` |
 | Order (gRPC + Kafka producer/consumer) | `cmd/payflow/order/main.go` | Configurable via `ORDER_GRPC_PORT` |
 
 ### Infrastructure (Docker Compose)
 
-- **order-db**: Postgres 15 on port 5432
-- **inventory-db**: Postgres 15 on port 5433
+- **auth-db**: Postgres 15 on port 5434, init from `sql/init_auth.sql`
+- **order-db**: Postgres 15 on port 5432, init from `sql/init_order.sql`
+- **inventory-db**: Postgres 15 on port 5433, init from `sql/init_inventory.sql`
 - **Kafka**: Apache Kafka 3.9.1 (KRaft, port 9092)
 - **pgAdmin**: Port 8888
-- **Dozzle**: Port 8080
+- **Dozzle**: Port 8081
+- **auth**: gRPC server on port 50053, JWT auth, login/register RPCs
 - **product**: gRPC server on port 50052, Kafka consumer
 - **order**: gRPC server on port 50051, Kafka producer/consumer
-- **apigateway**: HTTP server on port 8080, grpc-gateway proxying to product + order
+- **apigateway**: HTTP server on port 8080, grpc-gateway proxying to auth + product + order
+- **frontend**: nginx serving SPA on port 3000
 
 ### Environment Variables
 
@@ -53,10 +57,18 @@ INVENTORY_DB_PASSWORD=changeme
 INVENTORY_DB_PORT=5433
 PRODUCT_GRPC_PORT=:50052
 
+# Auth service
+AUTH_DB_HOST=localhost
+AUTH_DB_USER=root
+AUTH_DB_PASSWORD=changeme
+AUTH_DB_PORT=5434
+AUTH_GRPC_PORT=:50053
+
 # API gateway
 APIGATEWAY_PORT=:8080
 ORDER_SERVICE=localhost:50051
 PRODUCT_SERVICE=localhost:50052
+AUTH_SERVICE=localhost:50053
 JWT_SECRET_KEY=change-me
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
-      - 8080:8080
+      - 8081:8080
   product:
     container_name: product
     build:

--- a/internal/apigateway/middleware/auth.go
+++ b/internal/apigateway/middleware/auth.go
@@ -19,10 +19,17 @@ var publicPaths = map[string]bool{
 	"/api/auth/register": true,
 }
 
+func isPublicPath(path string) bool {
+	if publicPaths[path] {
+		return true
+	}
+	return strings.HasPrefix(path, "/api/products")
+}
+
 func AuthMiddleware(logger zerolog.Logger, jwtSecret string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if publicPaths[r.URL.Path] {
+			if isPublicPath(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/apigateway/router/router.go
+++ b/internal/apigateway/router/router.go
@@ -9,16 +9,28 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	authgw "github.com/skhanal5/payflow/gen/go/auth"
 	ordergw "github.com/skhanal5/payflow/gen/go/order"
 	productgw "github.com/skhanal5/payflow/gen/go/product"
 
 	"github.com/skhanal5/payflow/internal/apigateway/handler"
+	"github.com/skhanal5/payflow/internal/shared/auth"
 )
 
 func NewRouter(ctx context.Context, logger zerolog.Logger, productAddr, orderAddr, authAddr string) (http.Handler, error) {
-	gwmux := runtime.NewServeMux()
+	gwmux := runtime.NewServeMux(
+		runtime.WithMetadata(func(ctx context.Context, req *http.Request) metadata.MD {
+			if claims, ok := auth.GetUserClaimsFromContext(ctx); ok {
+				md, err := auth.ClaimsToMetadata(claims)
+				if err == nil {
+					return md
+				}
+			}
+			return metadata.MD{}
+		}),
+	)
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/internal/auth/repository/repository.go
+++ b/internal/auth/repository/repository.go
@@ -18,7 +18,7 @@ type UserRepository interface {
 }
 
 func NewUserDB(host, user, password, port string) *UserDB {
-	dsn := db.DefineGormDSN(host, user, password, port)
+	dsn := db.DefineGormDSN(host, user, password, port, "auth")
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
 		panic("failed to connect to auth database")

--- a/internal/order/repository/model.go
+++ b/internal/order/repository/model.go
@@ -8,7 +8,7 @@ type Order struct {
 	UserId          string      `gorm:"not null"`
 	Status          string      `gorm:"not null"`
 	ShippingAddress string      `gorm:"not null"`
-	OrderItems      []OrderItem `gorm:"foreignKey:OrderId"`
+	OrderItems      []OrderItem `gorm:"foreignKey:OrderId;references:OrderId"`
 }
 
 type OrderItem struct {

--- a/internal/order/repository/order.go
+++ b/internal/order/repository/order.go
@@ -19,7 +19,7 @@ type OrderRepository interface {
 }
 
 func NewOrderDB(host string, user string, password string, port string) *OrderDB {
-	dsn := db.DefineGormDSN(host, user, password, port)
+	dsn := db.DefineGormDSN(host, user, password, port, "order")
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 
 	if err != nil {

--- a/internal/product/interceptor/authz.go
+++ b/internal/product/interceptor/authz.go
@@ -15,15 +15,18 @@ import (
 type AuthzRules map[string][]string
 
 func NewAuthzRules() AuthzRules {
-	return AuthzRules{
-		"/product.ProductService/GetProduct":   {},
-		"/product.ProductService/ListProducts": {},
-	}
+	return AuthzRules{}
 }
 
 func AuthzInterceptor(logger zerolog.Logger, rules AuthzRules) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		logger.Debug().Str("method", info.FullMethod).Msg("Intercepting gRPC call for authorization")
+
+		requiredRoles, found := rules[info.FullMethod]
+		if !found {
+			logger.Debug().Str("method", info.FullMethod).Msg("Method not in authz rules. Allowing without authentication.")
+			return handler(ctx, req)
+		}
 
 		claims, ok := auth.GetUserClaimsFromContext(ctx)
 		if !ok {
@@ -33,9 +36,7 @@ func AuthzInterceptor(logger zerolog.Logger, rules AuthzRules) grpc.UnaryServerI
 
 		logger.Debug().Str("method", info.FullMethod).Str("userID", claims.UserID).Str("role", claims.Role).Msg("User claims found")
 
-		requiredRoles, found := rules[info.FullMethod]
-
-		if !found || len(requiredRoles) == 0 {
+		if len(requiredRoles) == 0 {
 			logger.Debug().Str("method", info.FullMethod).Msg("Method found in rules with no specific roles required. Allowing.")
 			return handler(ctx, req)
 		}

--- a/internal/product/repository/product.go
+++ b/internal/product/repository/product.go
@@ -20,7 +20,7 @@ type ProductDB struct {
 }
 
 func NewProductDB(host string, user string, password string, port string) *ProductDB {
-	dsn := db.DefineGormDSN(host, user, password, port)
+	dsn := db.DefineGormDSN(host, user, password, port, "inventory")
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
 		//TODO: Add error message

--- a/internal/shared/auth/auth.go
+++ b/internal/shared/auth/auth.go
@@ -12,8 +12,9 @@ type contextKey string
 
 const (
 	UserClaimsContextKey contextKey = "userClaims"
-	ClaimsMetadataKey              = "x-user-claims"
 )
+
+const ClaimsMetadataKey = "x-user-claims"
 
 type UserClaims struct {
 	UserID string `json:"user_id"`

--- a/internal/shared/auth/auth.go
+++ b/internal/shared/auth/auth.go
@@ -2,23 +2,54 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/grpc/metadata"
 )
 
 type contextKey string
 
 const (
 	UserClaimsContextKey contextKey = "userClaims"
+	ClaimsMetadataKey              = "x-user-claims"
 )
 
 type UserClaims struct {
 	UserID string `json:"user_id"`
-	Role   string `json:"role"` // e.g., "admin", "user", "guest"
+	Role   string `json:"role"`
 	jwt.RegisteredClaims
 }
 
 func GetUserClaimsFromContext(ctx context.Context) (*UserClaims, bool) {
 	claims, ok := ctx.Value(UserClaimsContextKey).(*UserClaims)
+	if ok {
+		return claims, true
+	}
+	claims, ok = getUserClaimsFromMetadata(ctx)
 	return claims, ok
+}
+
+func getUserClaimsFromMetadata(ctx context.Context) (*UserClaims, bool) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, false
+	}
+	vals := md.Get(ClaimsMetadataKey)
+	if len(vals) == 0 {
+		return nil, false
+	}
+	var claims UserClaims
+	if err := json.Unmarshal([]byte(vals[0]), &claims); err != nil {
+		return nil, false
+	}
+	return &claims, true
+}
+
+func ClaimsToMetadata(claims *UserClaims) (metadata.MD, error) {
+	data, err := json.Marshal(claims)
+	if err != nil {
+		return nil, err
+	}
+	return metadata.Pairs(ClaimsMetadataKey, string(data)), nil
 }

--- a/internal/shared/db/db.go
+++ b/internal/shared/db/db.go
@@ -2,6 +2,6 @@ package db
 
 import "fmt"
 
-func DefineGormDSN(host string, user string, password string, port string) string {
-	return fmt.Sprintf("host=%s user=%s password=%s port=%s sslmode=disable TimeZone=Asia/Shanghai", host, user, password, port)
+func DefineGormDSN(host, user, password, port, dbname string) string {
+	return fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=Asia/Shanghai", host, user, password, dbname, port)
 }


### PR DESCRIPTION
### Bug fixes
- **Dozzle port conflict**: Moved Dozzle from `8080` to `8081` to avoid conflict with apigateway (both were on the same host port)
- **DSN missing dbname** (`internal/shared/db/db.go`): Connection string had no `dbname=` parameter, so PostgreSQL defaulted to the user name (`root`). The databases are named `auth`, `order`, and `inventory` — all 3 services panicked on startup with `database "root" does not exist`
- **Auth claims not forwarded** (`internal/apigateway/router/router.go`, `internal/shared/auth/auth.go`): Gateway parsed the JWT and stored claims in the HTTP context but never forwarded them to downstream gRPC services. All authenticated endpoints returned `Authentication required`. Fixed by:
  - Adding `runtime.WithMetadata` to the gRPC-gateway mux
  - Adding metadata → context extraction fallback in `GetUserClaimsFromContext`
- **Order FK violation** (`internal/order/repository/model.go`): GORM's `foreignKey:OrderId` annotation defaulted to referencing the auto-increment primary key (`Order.ID`) instead of the business key (`Order.OrderId`), causing `order_items.order_id` to not match any `orders.order_id` value
- **Products requiring auth** (`internal/apigateway/middleware/auth.go`, `internal/product/interceptor/authz.go`): Changed products to be publicly browseable (no login required); orders remain auth-protected
### Documentation
- Updated README and AGENTS.md with auth service, auth-db, frontend service, corrected env vars (auth block, `AUTH_SERVICE`), and fixed service count (2 → 3 gRPC services)
### Tooling
- Makefile `restart-db`: added `auth-db`
- Makefile `ps`: switched from deprecated `docker-compose` (v1) to `docker compose` (v2)
- Makefile `help`: renamed non-existent `prune` target to `clean`